### PR TITLE
Enable win and py<35

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,7 @@
+if "%ARCH%" == "32" (set PLATFORM=x86) else (set PLATFORM=x64)
+call "%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %PLATFORM%
+set DISTUTILS_USE_SDK=1
+set MSSdk=1
 "%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
 if errorlevel 1 exit 1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,7 @@ source:
   md5: 0d3c0f5f555edc39dc98fd3758249bed
 
 build:
-  number: 1
-  skip: true  # [win and py<35]
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
@msarahan I think that it is important to allow this. Otherwise we effectively disallow extensions written with modern C++  that won't build with antiquated MSVC compiler versions.
