### PR TITLE
make pyarrow 0.4.0 the required min version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   md5: e5bc36af8a2bdbe34a0af2a602b7c1b8
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win32]
   skip: true  # [win and py<35]
   features:
@@ -22,7 +22,7 @@ requirements:
   run:
     - python
     - pandas >=0.19.2
-    - pyarrow
+    - pyarrow >=0.4.0
 
 test:
   imports:


### PR DESCRIPTION
@wesm needs this to upgrade existing installations